### PR TITLE
Port struct to maps and restructure namespaces

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha16"]
                  [org.clojure/clojurescript "1.9.562"]]
 
   :plugins [[lein-kibit "0.1.5"]
             [lein-cljsbuild "1.1.6"]]
+
+  :profiles {:dev {:dependencies [[spyscope "0.1.6"]]
+                   :injections [(require 'spyscope.core)]}}
 
   :cljsbuild {:builds [{:source-paths ["src"]
                         :compiler {:output-to "src-js/build.js"

--- a/src/edn_diff/core.cljc
+++ b/src/edn_diff/core.cljc
@@ -22,7 +22,7 @@
 (defn min-edit
   "select a edit with the minimal distance for a list of edits"
   [& edits]
-  (apply min-key :distance edits))
+  (apply min-key ::e/distance edits))
 
 (defn initial-distance
   "for a list return the edits representing the distance for building

--- a/src/edn_diff/core.cljc
+++ b/src/edn_diff/core.cljc
@@ -12,95 +12,12 @@
 
   https://github.com/stamourv/sexp-diff/tree/master/sexp-diff
   http://wiki.call-cc.org/eggref/4/sexp-diff
-  https://github.com/michaelw/mw-diff-sexp")
+  https://github.com/michaelw/mw-diff-sexp"
+  (:require [edn-diff.edit :as e]
+            [edn-diff.render :as r]))
 
-;; structure to track and compare edits
-(defstruct edit :type :distance :change)
-(defstruct update-edition :type :distance :old :new)
 
 (declare levenshtein-tree-edit)
-
-(defn tree-size
-  "calculate number of leaf in a tree"
-  [tree]
-  (if (coll? tree)
-    (apply + 1 (map tree-size tree))
-    1))
-
-(defn unchanged-edit
-  "edit who's distance is the same as the distance of its content."
-  [change]
-  (struct edit :unchanged (tree-size change) change))
-
-(defn deletion-edit
-  "edit representing the distance of removing its content"
-  [change]
-  (struct edit :deletion (inc (tree-size change)) change))
-
-(defn insertion-edit
-  "edit representing the distance of adding its content"
-  [change]
-  (struct edit :insertion (inc (tree-size change)) change))
-
-(defn update-edit
-  "edit representing the distance of removing the old content adding
-  the new content"
-  [old new]
-  (struct update-edition
-          :update
-          (+ 1 (tree-size old)
-             1 (tree-size new))
-          old
-          new))
-
-(defn compound-edit
-  "edit representing the distance of chaining multiple edit together"
-  [changes]
-  (struct edit :compound (apply + (map :distance changes)) changes))
-
-(defn empty-compound-edit
-  "edit representing a empty chain of edits.
-
-  note that the distance of '() is 1"
-  []
-  (compound-edit '()))
-
-(defn extend-compound-edit
-  "add edit to a chain of edit"
-  [edit-chain edit]
-  (compound-edit (cons edit (:change edit-chain))))
-
-(defmulti render-difference
-  "rebuild s-exp from edit and apply change marker to element that
-  differs"
-  (fn [edits _ _]
-    (:type edits)))
-
-(defmethod render-difference :unchanged
-  [edits old-marker new-marker]
-  (list (:change edits)))
-
-(defmethod render-difference :deletion
-  [edits old-marker new-marker]
-  (list old-marker (:change edits)))
-
-(defmethod render-difference :insertion
-  [edits old-marker new-marker]
-  (list new-marker (:change edits)))
-
-(defmethod render-difference :update
-  [edits old-marker new-marker]
-  (list old-marker (:old edits)
-        new-marker (:new edits)))
-
-(defmethod render-difference :compound
-  [edits old-marker new-marker]
-  (list (reduce (fn [res r]
-                  (concat res (render-difference r
-                                                 old-marker
-                                                 new-marker)))
-                '()
-                (reverse (:change edits)))))
 
 (defn min-edit
   "select a edit with the minimal distance for a list of edits"
@@ -139,8 +56,8 @@
       {:type :unchanged, :distance 1, :change 1})}]"
   [edit-type-fn lst]
   (reduce (fn [ss l]
-            (conj ss (extend-compound-edit (last ss) (edit-type-fn l))))
-          [(empty-compound-edit)]
+            (conj ss (e/extend-compound-edit (last ss) (edit-type-fn l))))
+          [(e/empty-compound-edit)]
           lst))
 
 (defn levenshtein-list-row-edit
@@ -148,12 +65,12 @@
   table and return the best and current edit that minimizes the
   distance."
   [new-part {:keys [best current row col]} [old-part row-idx]]
-  (let [best-edit (min-edit (extend-compound-edit (get row (inc row-idx))
-                                                  (insertion-edit new-part))
-                            (extend-compound-edit  current
-                                                   (deletion-edit old-part))
-                            (extend-compound-edit (get row row-idx)
-                                                  (levenshtein-tree-edit old-part new-part)))]
+  (let [best-edit (min-edit (e/extend-compound-edit (get row (inc row-idx))
+                                                    (e/insertion-edit new-part))
+                            (e/extend-compound-edit  current
+                                                     (e/deletion-edit old-part))
+                            (e/extend-compound-edit (get row row-idx)
+                                                    (levenshtein-tree-edit old-part new-part)))]
     {:row (assoc row row-idx current)
      :current best-edit
      :best best-edit
@@ -178,8 +95,8 @@
   note the old list of columns of the levenshtein table
   and the new list id the rows of the levenshtein table"
   [old-list new-list]
-  (let [row (initial-distance deletion-edit old-list)
-        col (initial-distance insertion-edit new-list)]
+  (let [row (initial-distance e/deletion-edit old-list)
+        col (initial-distance e/insertion-edit new-list)]
     (-> (reduce (partial levenshtein-list-col-edit old-list)
                 {:best false
                  :row row
@@ -193,13 +110,13 @@
   between the two list as a smallest tree of edits."
   [old-tree new-tree]
   (cond
-    (= old-tree new-tree) (unchanged-edit old-tree)
+    (= old-tree new-tree) (e/unchanged-edit old-tree)
     (not (and (coll? old-tree)
               (not-empty old-tree)
               (coll? new-tree)
-              (not-empty new-tree))) (update-edit old-tree new-tree)
+              (not-empty new-tree))) (e/update-edit old-tree new-tree)
     :else (min-edit
-           (update-edit old-tree new-tree)
+           (e/update-edit old-tree new-tree)
            (levenshtein-list-edit old-tree new-tree))))
 
 (defn sexp-diff
@@ -208,5 +125,5 @@
   with the :old and :new markers.
   :old is what is being removed and :new is what is being added"
   [old-tree new-tree]
-  (render-difference (levenshtein-tree-edit old-tree new-tree)
-                     :old :new))
+  (r/render-difference (levenshtein-tree-edit old-tree new-tree)
+                       :old :new))

--- a/src/edn_diff/edit.cljc
+++ b/src/edn_diff/edit.cljc
@@ -1,0 +1,54 @@
+(ns edn-diff.edit
+  "structure to track and compare edits")
+
+(defstruct edit :type :distance :change)
+(defstruct update-edition :type :distance :old :new)
+
+(defn tree-size
+  "calculate number of leaf in a tree"
+  [tree]
+  (if (coll? tree)
+    (apply + 1 (map tree-size tree))
+    1))
+
+(defn unchanged-edit
+  "edit who's distance is the same as the distance of its content."
+  [change]
+  (struct edit :unchanged (tree-size change) change))
+
+(defn deletion-edit
+  "edit representing the distance of removing its content"
+  [change]
+  (struct edit :deletion (inc (tree-size change)) change))
+
+(defn insertion-edit
+  "edit representing the distance of adding its content"
+  [change]
+  (struct edit :insertion (inc (tree-size change)) change))
+
+(defn update-edit
+  "edit representing the distance of removing the old content adding
+  the new content"
+  [old new]
+  (struct update-edition
+          :update
+          (+ 1 (tree-size old)
+             1 (tree-size new))
+          old
+          new))
+
+(defn compound-edit
+  "edit representing the distance of chaining multiple edit together"
+  [changes]
+  (struct edit :compound (apply + (map :distance changes)) changes))
+
+(defn empty-compound-edit
+  "edit representing a empty chain of edits.
+  note that the distance of '() is 1"
+  []
+  (compound-edit '()))
+
+(defn extend-compound-edit
+  "add edit to a chain of edit"
+  [edit-chain edit]
+  (compound-edit (cons edit (:change edit-chain))))

--- a/src/edn_diff/render.cljc
+++ b/src/edn_diff/render.cljc
@@ -1,28 +1,29 @@
 (ns edn-diff.render
-  "rendering to transform edits in more readable changes")
+  "rendering to transform edits in more readable changes"
+  (:require [edn-diff.edit :as e]))
 
 (defmulti render-difference
   "rebuild s-exp from edit and apply change marker to element that
   differs"
   (fn [edits _ _]
-    (:type edits)))
+    (::e/type edits)))
 
 (defmethod render-difference :unchanged
   [edits old-marker new-marker]
-  (list (:change edits)))
+  (list (::e/change edits)))
 
 (defmethod render-difference :deletion
   [edits old-marker new-marker]
-  (list old-marker (:change edits)))
+  (list old-marker (::e/change edits)))
 
 (defmethod render-difference :insertion
   [edits old-marker new-marker]
-  (list new-marker (:change edits)))
+  (list new-marker (::e/change edits)))
 
 (defmethod render-difference :update
   [edits old-marker new-marker]
-  (list old-marker (:old edits)
-        new-marker (:new edits)))
+  (list old-marker (::e/old edits)
+        new-marker (::e/new edits)))
 
 (defmethod render-difference :compound
   [edits old-marker new-marker]
@@ -31,4 +32,4 @@
                                                  old-marker
                                                  new-marker)))
                 '()
-                (reverse (:change edits)))))
+                (reverse (::e/change edits)))))

--- a/src/edn_diff/render.cljc
+++ b/src/edn_diff/render.cljc
@@ -1,0 +1,34 @@
+(ns edn-diff.render
+  "rendering to transform edits in more readable changes")
+
+(defmulti render-difference
+  "rebuild s-exp from edit and apply change marker to element that
+  differs"
+  (fn [edits _ _]
+    (:type edits)))
+
+(defmethod render-difference :unchanged
+  [edits old-marker new-marker]
+  (list (:change edits)))
+
+(defmethod render-difference :deletion
+  [edits old-marker new-marker]
+  (list old-marker (:change edits)))
+
+(defmethod render-difference :insertion
+  [edits old-marker new-marker]
+  (list new-marker (:change edits)))
+
+(defmethod render-difference :update
+  [edits old-marker new-marker]
+  (list old-marker (:old edits)
+        new-marker (:new edits)))
+
+(defmethod render-difference :compound
+  [edits old-marker new-marker]
+  (list (reduce (fn [res r]
+                  (concat res (render-difference r
+                                                 old-marker
+                                                 new-marker)))
+                '()
+                (reverse (:change edits)))))

--- a/test/edn_diff/core_test.clj
+++ b/test/edn_diff/core_test.clj
@@ -11,21 +11,21 @@
            (count (initial-distance e/unchanged-edit
                                     '(1 2 3 4))))))
   (testing "that initial-distance return a lists of edit"
-    (is (= [{:type :compound :distance 0 :change '()}
-            {:type :compound
-             :distance 1
-             :change '({:type :unchanged :distance 1 :change 1})}
-            {:type :compound
-             :distance 2
-             :change
-             '({:type :unchanged :distance 1 :change 2}
-               {:type :unchanged :distance 1 :change 1})}
-            {:type :compound
-             :distance 3
-             :change
-             '({:type :unchanged :distance 1 :change 3}
-               {:type :unchanged :distance 1 :change 2}
-               {:type :unchanged :distance 1 :change 1})}]
+    (is (= [{::e/type :compound ::e/distance 0 ::e/change '()}
+            {::e/type :compound
+             ::e/distance 1
+             ::e/change '({::e/type :unchanged ::e/distance 1 ::e/change 1})}
+            {::e/type :compound
+             ::e/distance 2
+             ::e/change
+             '({::e/type :unchanged ::e/distance 1 ::e/change 2}
+               {::e/type :unchanged ::e/distance 1 ::e/change 1})}
+            {::e/type :compound
+             ::e/distance 3
+             ::e/change
+             '({::e/type :unchanged ::e/distance 1 ::e/change 3}
+               {::e/type :unchanged ::e/distance 1 ::e/change 2}
+               {::e/type :unchanged ::e/distance 1 ::e/change 1})}]
            (initial-distance e/unchanged-edit '(1 2 3))))))
 
 (deftest sexp-diff-test

--- a/test/edn_diff/core_test.clj
+++ b/test/edn_diff/core_test.clj
@@ -1,98 +1,14 @@
 (ns edn-diff.core-test
   (:require [clojure.test :refer :all]
+            [edn-diff.edit :as e]
             [edn-diff.core :refer :all]))
-
-(deftest tree-size-test
-  (testing "tree size return correct counts"
-    (testing "base elemenents"
-      (testing "empty list"
-        (is (= 1
-               (tree-size '()))))
-      (testing "non collection elemenents"
-        (is (= 1
-               (tree-size 1)))
-        (is (= 1
-               (tree-size 'test)))
-        (is (= 1
-               (tree-size :test)))))
-    (testing "list structures"
-      (is (= 4
-             (tree-size '(1 2 3))))
-      (testing "nested list structures"
-        (is (= 7
-               (tree-size '(1 2 3 (4 5)))))))))
-
-(deftest edit-type-test
-  (testing "edit types"
-    (testing "unchanged"
-      (is (= :unchanged
-             (:type (unchanged-edit '())))))
-    (testing "deletion"
-      (is (= :deletion
-             (:type (deletion-edit '())))))
-    (testing "insertion"
-      (is (= :insertion
-             (:type (insertion-edit '())))))
-    (testing "update"
-      (is (= :update
-             (:type (update-edit '() '())))))
-    (testing "compound (chain edits)"
-      (testing "empty chain"
-        (is (= :compound
-               (:type (compound-edit '()))))
-        (is (= :compound
-               (:type (empty-compound-edit)))))
-      (testing "empty chain"
-        (is (= :compound
-               (:type (extend-compound-edit :test
-                                            (empty-compound-edit)))))))))
-
-(deftest render-test
-  (testing "that s-exp and be rebuilt"
-    (is (= '(1)
-           (render-difference {:type :unchanged
-                               :distance 1
-                               :change 1}
-                              :old
-                              :new)))
-    (is (= '((1 2 3))
-           (render-difference {:type :compound
-                               :distance 4
-                               :change (list {:type :unchanged, :distance 1, :change 3}
-                                             {:type :unchanged, :distance 1, :change 2}
-                                             {:type :unchanged, :distance 1, :change 1})}
-                              :old :new))))
-  (testing "that makers are applied to modification"
-    (testing "updates"
-      (is (= '(:old 1 :new 2)
-             (render-difference {:type :update :distance 4 :old 1 :new 2}
-                                :old
-                                :new))))
-    (testing "insertions"
-      (is (= '(:new 1)
-             (render-difference {:type :insertion :distance 1 :change 1}
-                                :old :new))))
-    (testing "deletion"
-      (is (= '(:old 1)
-             (render-difference {:type :deletion :distance 1 :change 1}
-                                :old :new))))
-    (testing "nested edit"
-      (is (= '((:old 1))
-             (render-difference {:type :compound
-                                 :distance 2
-                                 :change (list {:type :deletion :distance 1 :change 1})}
-                                :old :new))))
-    (testing "empty list"
-      (is (= '(())
-             (render-difference {:type :unchanged :distance 1 :change '()}
-                                :old :new))))))
 
 (deftest initial-distance-test
   ;; this test can be converted to a properly based generated test
   (testing "that initial-distance return the distance require to build
   the list"
     (is (= 5
-           (count (initial-distance unchanged-edit
+           (count (initial-distance e/unchanged-edit
                                     '(1 2 3 4))))))
   (testing "that initial-distance return a lists of edit"
     (is (= [{:type :compound :distance 0 :change '()}
@@ -110,7 +26,7 @@
              '({:type :unchanged :distance 1 :change 3}
                {:type :unchanged :distance 1 :change 2}
                {:type :unchanged :distance 1 :change 1})}]
-           (initial-distance unchanged-edit '(1 2 3))))))
+           (initial-distance e/unchanged-edit '(1 2 3))))))
 
 (deftest sexp-diff-test
   (testing "that diff are valid"

--- a/test/edn_diff/edit_test.cljc
+++ b/test/edn_diff/edit_test.cljc
@@ -1,0 +1,49 @@
+(ns edn-diff.edit-test
+  (:require [edn-diff.edit :refer :all]
+            #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all :include-macros true])))
+
+(deftest tree-size-test
+  (testing "tree size return correct counts"
+    (testing "base elemenents"
+      (testing "empty list"
+        (is (= 1
+               (tree-size '()))))
+      (testing "non collection elemenents"
+        (is (= 1
+               (tree-size 1)))
+        (is (= 1
+               (tree-size 'test)))
+        (is (= 1
+               (tree-size :test)))))
+    (testing "list structures"
+      (is (= 4
+             (tree-size '(1 2 3))))
+      (testing "nested list structures"
+        (is (= 7
+               (tree-size '(1 2 3 (4 5)))))))))
+
+(deftest edit-type-test
+  (testing "edit types"
+    (testing "unchanged"
+      (is (= :unchanged
+             (:type (unchanged-edit '())))))
+    (testing "deletion"
+      (is (= :deletion
+             (:type (deletion-edit '())))))
+    (testing "insertion"
+      (is (= :insertion
+             (:type (insertion-edit '())))))
+    (testing "update"
+      (is (= :update
+             (:type (update-edit '() '())))))
+    (testing "compound (chain edits)"
+      (testing "empty chain"
+        (is (= :compound
+               (:type (compound-edit '()))))
+        (is (= :compound
+               (:type (empty-compound-edit)))))
+      (testing "empty chain"
+        (is (= :compound
+               (:type (extend-compound-edit :test
+                                            (empty-compound-edit)))))))))

--- a/test/edn_diff/edit_test.cljc
+++ b/test/edn_diff/edit_test.cljc
@@ -1,5 +1,5 @@
 (ns edn-diff.edit-test
-  (:require [edn-diff.edit :refer :all]
+  (:require [edn-diff.edit :refer :all :as e]
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer :all :include-macros true])))
 
@@ -27,23 +27,23 @@
   (testing "edit types"
     (testing "unchanged"
       (is (= :unchanged
-             (:type (unchanged-edit '())))))
+             (::e/type (unchanged-edit '())))))
     (testing "deletion"
       (is (= :deletion
-             (:type (deletion-edit '())))))
+             (::e/type (deletion-edit '())))))
     (testing "insertion"
       (is (= :insertion
-             (:type (insertion-edit '())))))
+             (::e/type (insertion-edit '())))))
     (testing "update"
       (is (= :update
-             (:type (update-edit '() '())))))
+             (::e/type (update-edit '() '())))))
     (testing "compound (chain edits)"
       (testing "empty chain"
         (is (= :compound
-               (:type (compound-edit '()))))
+               (::e/type (compound-edit '()))))
         (is (= :compound
-               (:type (empty-compound-edit)))))
+               (::e/type (empty-compound-edit)))))
       (testing "empty chain"
         (is (= :compound
-               (:type (extend-compound-edit :test
-                                            (empty-compound-edit)))))))))
+               (::e/type (extend-compound-edit :test
+                                               (empty-compound-edit)))))))))

--- a/test/edn_diff/render_test.cljc
+++ b/test/edn_diff/render_test.cljc
@@ -1,0 +1,44 @@
+(ns edn-diff.render-test
+  (:require [edn-diff.render :refer :all]
+            #?(:clj [clojure.test :refer :all]
+               :cljs [cljs.test :refer :all :include-macros true])))
+
+(deftest render-test
+  (testing "that s-exp and be rebuilt"
+    (is (= '(1)
+           (render-difference {:type :unchanged
+                               :distance 1
+                               :change 1}
+                              :old
+                              :new)))
+    (is (= '((1 2 3))
+           (render-difference {:type :compound
+                               :distance 4
+                               :change (list {:type :unchanged, :distance 1, :change 3}
+                                             {:type :unchanged, :distance 1, :change 2}
+                                             {:type :unchanged, :distance 1, :change 1})}
+                              :old :new))))
+  (testing "that makers are applied to modification"
+    (testing "updates"
+      (is (= '(:old 1 :new 2)
+             (render-difference {:type :update :distance 4 :old 1 :new 2}
+                                :old
+                                :new))))
+    (testing "insertions"
+      (is (= '(:new 1)
+             (render-difference {:type :insertion :distance 1 :change 1}
+                                :old :new))))
+    (testing "deletion"
+      (is (= '(:old 1)
+             (render-difference {:type :deletion :distance 1 :change 1}
+                                :old :new))))
+    (testing "nested edit"
+      (is (= '((:old 1))
+             (render-difference {:type :compound
+                                 :distance 2
+                                 :change (list {:type :deletion :distance 1 :change 1})}
+                                :old :new))))
+    (testing "empty list"
+      (is (= '(())
+             (render-difference {:type :unchanged :distance 1 :change '()}
+                                :old :new))))))

--- a/test/edn_diff/render_test.cljc
+++ b/test/edn_diff/render_test.cljc
@@ -1,44 +1,45 @@
 (ns edn-diff.render-test
   (:require [edn-diff.render :refer :all]
+            [edn-diff.edit :as e]
             #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer :all :include-macros true])))
 
 (deftest render-test
   (testing "that s-exp and be rebuilt"
     (is (= '(1)
-           (render-difference {:type :unchanged
-                               :distance 1
-                               :change 1}
+           (render-difference {::e/type :unchanged
+                               ::e/distance 1
+                               ::e/change 1}
                               :old
                               :new)))
     (is (= '((1 2 3))
-           (render-difference {:type :compound
-                               :distance 4
-                               :change (list {:type :unchanged, :distance 1, :change 3}
-                                             {:type :unchanged, :distance 1, :change 2}
-                                             {:type :unchanged, :distance 1, :change 1})}
+           (render-difference {::e/type :compound
+                               ::e/distance 4
+                               ::e/change (list {::e/type :unchanged, ::e/distance 1, ::e/change 3}
+                                                {::e/type :unchanged, ::e/distance 1, ::e/change 2}
+                                                {::e/type :unchanged, ::e/distance 1, ::e/change 1})}
                               :old :new))))
   (testing "that makers are applied to modification"
     (testing "updates"
       (is (= '(:old 1 :new 2)
-             (render-difference {:type :update :distance 4 :old 1 :new 2}
+             (render-difference {::e/type :update ::e/distance 4 ::e/old 1 ::e/new 2}
                                 :old
                                 :new))))
     (testing "insertions"
       (is (= '(:new 1)
-             (render-difference {:type :insertion :distance 1 :change 1}
+             (render-difference {::e/type :insertion ::e/distance 1 ::e/change 1}
                                 :old :new))))
     (testing "deletion"
       (is (= '(:old 1)
-             (render-difference {:type :deletion :distance 1 :change 1}
+             (render-difference {::e/type :deletion ::e/distance 1 ::e/change 1}
                                 :old :new))))
     (testing "nested edit"
       (is (= '((:old 1))
-             (render-difference {:type :compound
-                                 :distance 2
-                                 :change (list {:type :deletion :distance 1 :change 1})}
+             (render-difference {::e/type :compound
+                                 ::e/distance 2
+                                 ::e/change (list {::e/type :deletion ::e/distance 1 ::e/change 1})}
                                 :old :new))))
     (testing "empty list"
       (is (= '(())
-             (render-difference {:type :unchanged :distance 1 :change '()}
+             (render-difference {::e/type :unchanged ::e/distance 1 ::e/change '()}
                                 :old :new))))))


### PR DESCRIPTION
Port struct to maps and add core.spec to describe it. This change required that all non namespace keyword used in the initial edit structure be converted to use namespace keywords.

The edn-diff.core namespace was also broken-up into a edit namespace for all edit structure related things and a render namespace for all thing that rebuild the s-exp